### PR TITLE
Fixup the git template cloning

### DIFF
--- a/ecology-core/src/Irreverent/Ecology/Core/Data.hs
+++ b/ecology-core/src/Irreverent/Ecology/Core/Data.hs
@@ -32,6 +32,7 @@ module Irreverent.Ecology.Core.Data (
   , EnvironmentVariableName(..)
   , EnvironmentVariableValue(..)
   , GitTemplateRepo(..)
+  , GitTemplateHistoryAction(..)
   , GitRepository(..)
   , NewCIInfo(..)
   , NewGitRepository(..)
@@ -63,6 +64,16 @@ data GitTemplateRepo = GitTemplateRepo {
     gitTemplateRepoURL  :: !T.Text
   , gitTemplatePrivacy  :: !EcologyPrivacy
   } deriving (Show, Eq)
+
+-- |
+-- When creating another project from a template
+-- there is an option of keep the template git history,
+-- and removing it, with ecology creating a new
+-- initial commit with the content.
+data GitTemplateHistoryAction =
+    KeepTemplateHistory
+  | RemoveTemplateHistory
+    deriving (Show, Eq)
 
 data GitRepository = GitRepository {
     gitRepoName :: !T.Text


### PR DESCRIPTION
- Add an option to keep the template history if you wish
- In the case where the tempalte history is squashed, its not currently done in such a way that 
  submodules in the template are preserved. A `git read-tree` style import is required for this.